### PR TITLE
redraw_minimenu: add format string

### DIFF
--- a/src/ui/cursesui.cc
+++ b/src/ui/cursesui.cc
@@ -194,7 +194,7 @@ void CursesInterface::Pimpl::redraw_minimenu()
 {
 	werase(minimenu_w_);
 	wmove(minimenu_w_, 0, 0);
-	wprintw(minimenu_w_,
+	wprintw(minimenu_w_, "%s",
 		parent_.to_locale(_("[SP] <number> R)epl A)ccept I)nsert L)ookup U)ncap Q)uit "
 				    "e(X)it or ? for help")).c_str());
 	wrefresh(minimenu_w_);


### PR DESCRIPTION
On Fedora Rawhide (the upcoming Fedora 37), the build fails with

```
g++ -DHAVE_CONFIG_H -I. -I/usr/include/glibmm-2.4 -I/usr/lib64/glibmm-2.4/include -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -I/usr/include/sysprof-4 -pthread -I/usr/include/sigc++-2.0 -I/usr/lib64/sigc++-2.0/include  -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1  -m64 -march=zEC12 -mtune=z13 -fasynchronous-unwind-tables -fstack-clash-protection    -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1  -m64 -march=zEC12 -mtune=z13 -fasynchronous-unwind-tables -fstack-clash-protection -c -o cursesui.o `test -f 'ui/cursesui.cc' || echo './'`ui/cursesui.cc
ui/cursesui.cc: In member function 'void CursesInterface::Pimpl::redraw_minimenu()':
ui/cursesui.cc:197:16: error: format not a string literal and no format arguments [-Werror=format-security]
  197 |         wprintw(minimenu_w_,
      |         ~~~~~~~^~~~~~~~~~~~~
  198 |                 parent_.to_locale(_("[SP] <number> R)epl A)ccept I)nsert L)ookup U)ncap Q)uit "
      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  199 |                                     "e(X)it or ? for help")).c_str());
      |                                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

This PR fixes the build by adding a format string.